### PR TITLE
Remove setting S3_bucket

### DIFF
--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -84,7 +84,6 @@ jobs:
         export GCS_SECRET='${{ secrets.gcs-secret }}'
         export AZURE_ACCOUNT_NAME='${{ secrets.azure-account-name }}'
         export AZURE_ACCOUNT_ACCESS_KEY='${{ secrets.azure-account-access-key }}'
-        export S3_BUCKET='${{ inputs.pytest-s3-bucket }}'
         export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest-markers }}' -o tmp_path_retention_policy=none"
 
         # Necessary to run git diff for doctests


### PR DESCRIPTION
Composer daily test now depend on the environment variable as a result of this PR https://github.com/mosaicml/composer/pull/3097/files#diff-9b51bddca1ee6939e679688418a5d0a0ff1e66cf6df7b10df1d015d1134972c0R116

This change sets the env var to None instead of an empty string to correctly get the right bucket