### PR TITLE
Add Workflow matrix to allow 1, 2, 4 gpus

### DIFF
--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -62,8 +62,6 @@ if __name__ == '__main__':
 
     clear_tmp_path_flag = '-o tmp_path_retention_policy=none'
     command += f'''
-    echo "---- DEBUG GPU COUNT is {args.gpu_num} of type {type(args.gpu_num)}"
-
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
     pip install --upgrade --user .{args.pip_deps}
@@ -111,6 +109,7 @@ if __name__ == '__main__':
 
     # Create run
     run = create_run(config)
+    print(f'---- DEBUG GPU COUNT is {args.gpu_num} of type {type(args.gpu_num)}')
     print(f'[GHA] Run created: {run.name}')
 
     # Wait until run starts before fetching logs

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -115,6 +115,7 @@ if __name__ == '__main__':
     run = wait_for_run_status(run, status='running')
     start_time = time.time()
     print('[GHA] Run started. Following logs...')
+    print(f'---- DEBUGGING {args.gpu_type}, {type(args.gpu_type)}')
 
     # Print logs
     for line in follow_run_logs(run):

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -4,6 +4,7 @@
 """Run pytest using MCLI."""
 
 import argparse
+import os
 import time
 
 from mcli import RunConfig, RunStatus, create_run, follow_run_logs, wait_for_run_status
@@ -61,6 +62,7 @@ if __name__ == '__main__':
 
     clear_tmp_path_flag = '-o tmp_path_retention_policy=none'
     command += f'''
+    echo "---- DEBUG GPU COUNT is {args.gpu_num} of type {type(args.gpu_num)}"
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
 
     clear_tmp_path_flag = '-o tmp_path_retention_policy=none'
     command += f'''
+    
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
     pip install --upgrade --user .{args.pip_deps}

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser.add_argument('--name', type=str, default='mcli-pytest', help='Base name of run')
     parser.add_argument('--cluster', type=str, default='r1z4', help='Cluster to use')
     parser.add_argument('--gpu_type', type=str, default='a100_40gb', help='Type of GPU to use')
-    parser.add_argument('--gpu_num', type=int, default=2, help='Number of the GPU to use')
+    parser.add_argument('--gpu_num', type=int, default=2, help='Number of GPUs to use')
     parser.add_argument('--image', type=str, default='mosaicml/pytorch:latest', help='Docker image to use')
     parser.add_argument('--git_branch', type=str, help='Git branch to check out')
     parser.add_argument('--git_commit', type=str, help='Git commit to check out. Overrides git_branch if specified')
@@ -22,9 +22,7 @@ if __name__ == '__main__':
     parser.add_argument('--git_ssh_clone', type=bool, default=False, help='Whether to use SSH to clone the repo')
     parser.add_argument('--pip_deps', type=str, help='Dependency group to install')
     parser.add_argument('--pip_package_name', type=str, default='', help='Name of pip package to install before running tests')
-    parser.add_argument('--pr_number',
-                        type=int,
-                        help='PR number to check out. Overrides git_branch/git_commit if specified')
+    parser.add_argument('--pr_number', type=int, help='PR number to check out. Overrides git_branch/git_commit if specified')
     parser.add_argument('--pytest_markers', type=str, help='Markers to pass to pytest')
     parser.add_argument('--pytest_command', type=str, help='Command to run pytest')
     parser.add_argument('--timeout', type=int, default=2700, help='Timeout for run (in seconds)')

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     clear_tmp_path_flag = '-o tmp_path_retention_policy=none'
     command += f'''
-    
+
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
     pip install --upgrade --user .{args.pip_deps}

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -67,11 +67,19 @@ if __name__ == '__main__':
     pip install --upgrade --user .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
+    '''
 
-    make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
+    if args.gpu_num == 1:
+        command += f'''
+        make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
+        '''
+    else:
+        world_size = args.gpu_num
+        command += f'''
+        make test-dist PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE={world_size}
+        '''
 
-    make test-dist PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
-
+    command += '''
     python -m coverage combine
 
     python -m coverage report

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -109,7 +109,6 @@ if __name__ == '__main__':
 
     # Create run
     run = create_run(config)
-    print(f'---- DEBUG GPU COUNT is {args.gpu_num} of type {type(args.gpu_num)}')
     print(f'[GHA] Run created: {run.name}')
 
     # Wait until run starts before fetching logs

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -107,19 +107,25 @@ if __name__ == '__main__':
         ],
     )
 
+    print(f'---- DEBUGGING {args.gpu_type}, {type(args.gpu_type)}')
+    print('Debug information printed successfully.')
+    sys.stdout.flush()
+
     # Create run
     run = create_run(config)
-    print(f'[GHA] ---- DEBUGGING {args.gpu_type}, {type(args.gpu_type)}')
     print(f'[GHA] Run created: {run.name}')
+    sys.stdout.flush()
 
     # Wait until run starts before fetching logs
     run = wait_for_run_status(run, status='running')
     start_time = time.time()
     print('[GHA] Run started. Following logs...')
+    sys.stdout.flush()
 
     # Print logs
     for line in follow_run_logs(run):
         print(line, end='')
+        sys.stdout.flush()
 
     print('[GHA] Run completed. Waiting for run to finish...')
     run = wait_for_run_status(run, status=RunStatus.COMPLETED)

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -107,25 +107,18 @@ if __name__ == '__main__':
         ],
     )
 
-    print(f'---- DEBUGGING {args.gpu_type}, {type(args.gpu_type)}')
-    print('Debug information printed successfully.')
-    sys.stdout.flush()
-
     # Create run
     run = create_run(config)
     print(f'[GHA] Run created: {run.name}')
-    sys.stdout.flush()
 
     # Wait until run starts before fetching logs
     run = wait_for_run_status(run, status='running')
     start_time = time.time()
     print('[GHA] Run started. Following logs...')
-    sys.stdout.flush()
 
     # Print logs
     for line in follow_run_logs(run):
         print(line, end='')
-        sys.stdout.flush()
 
     print('[GHA] Run completed. Waiting for run to finish...')
     run = wait_for_run_status(run, status=RunStatus.COMPLETED)

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -109,13 +109,13 @@ if __name__ == '__main__':
 
     # Create run
     run = create_run(config)
+    print(f'[GHA] ---- DEBUGGING {args.gpu_type}, {type(args.gpu_type)}')
     print(f'[GHA] Run created: {run.name}')
 
     # Wait until run starts before fetching logs
     run = wait_for_run_status(run, status='running')
     start_time = time.time()
     print('[GHA] Run started. Following logs...')
-    print(f'---- DEBUGGING {args.gpu_type}, {type(args.gpu_type)}')
 
     # Print logs
     for line in follow_run_logs(run):

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -39,6 +39,9 @@ on:
         required: false
         type: boolean
         default: false
+      gpu_configurations:
+        required: true
+        type: string
     secrets:
       mcloud-api-key:
         required: true
@@ -56,16 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gpu_num: [1, 2, 4]  # Define the GPU configurations to test
-        job_name: ['pytest-gpu-1', 'pytest-gpu-2', 'pytest-gpu-4']
-      include:
-        - gpu_num: 1
-          job_name: pytest-gpu-1
-        - gpu_num: 2
-          job_name: pytest-gpu-2
-        - gpu_num: 4
-          job_name: pytest-gpu-4
-    name: ${{ matrix.job_name }}
+        gpu_num: [${{ fromJSON(inputs.gpu_configurations) }}]
+    name: Pytest GPU ${{ matrix.gpu_num }}
     env:
       MOSAICML_API_KEY: ${{ secrets.mcloud-api-key }}
     steps:

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -45,14 +45,6 @@ on:
     secrets:
       mcloud-api-key:
         required: true
-      slack-notifications-bot-token:
-        required: false
-      code-eval-device:
-        required: false
-      code-eval-url:
-        required: false
-      code-eval-apikey:
-        required: false
 jobs:
   pytest-gpu:
     timeout-minutes: ${{ inputs.gha-timeout }}
@@ -62,12 +54,13 @@ jobs:
     steps:
     - name: Print Git Info
       run: |
-        echo "Branch: ${{ github.ref }}"
+        echo "Branch: 4gpu-testing"
         echo "SHA: ${{ github.sha }}"
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
         repository: "mosaicml/ci-testing"
+        ref: "4gpu-testing"
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -60,6 +60,10 @@ jobs:
     env:
       MOSAICML_API_KEY: ${{ secrets.mcloud-api-key }}
     steps:
+    - name: Print Git Info
+      run: |
+        echo "Branch: ${{ github.ref }}"
+        echo "SHA: ${{ github.sha }}"
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -39,9 +39,9 @@ on:
         required: false
         type: boolean
         default: false
-      gpu_configurations:
+      gpu_num:
         required: true
-        type: string
+        type: number
     secrets:
       mcloud-api-key:
         required: true
@@ -57,10 +57,6 @@ jobs:
   pytest-gpu:
     timeout-minutes: ${{ inputs.gha-timeout }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        gpu_num: [${{ fromJSON(inputs.gpu_configurations) }}]
-    name: Pytest GPU ${{ matrix.gpu_num }}
     env:
       MOSAICML_API_KEY: ${{ secrets.mcloud-api-key }}
     steps:
@@ -115,6 +111,6 @@ jobs:
           --pytest_markers '${{ inputs.pytest-markers }}' \
           --pytest_command '${{ inputs.pytest-command }}' \
           --timeout ${{ inputs.mcloud-timeout }} \
-          --gpu_num ${{ matrix.gpu_num }} \
+          --gpu_num ${{ inputs.gpu_num }} \
           --git_ssh_clone ${{ inputs.git-ssh-clone }} \
           ${REF_ARGS}

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -45,6 +45,14 @@ on:
     secrets:
       mcloud-api-key:
         required: true
+      slack-notifications-bot-token:
+        required: false
+      code-eval-device:
+        required: false
+      code-eval-url:
+        required: false
+      code-eval-apikey:
+        required: false
 jobs:
   pytest-gpu:
     timeout-minutes: ${{ inputs.gha-timeout }}

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -54,6 +54,18 @@ jobs:
   pytest-gpu:
     timeout-minutes: ${{ inputs.gha-timeout }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gpu_num: [1, 2, 4]  # Define the GPU configurations to test
+        job_name: ['pytest-gpu-1', 'pytest-gpu-2', 'pytest-gpu-4']
+      include:
+        - gpu_num: 1
+          job_name: pytest-gpu-1
+        - gpu_num: 2
+          job_name: pytest-gpu-2
+        - gpu_num: 4
+          job_name: pytest-gpu-4
+    name: ${{ matrix.job_name }}
     env:
       MOSAICML_API_KEY: ${{ secrets.mcloud-api-key }}
     steps:
@@ -108,5 +120,6 @@ jobs:
           --pytest_markers '${{ inputs.pytest-markers }}' \
           --pytest_command '${{ inputs.pytest-command }}' \
           --timeout ${{ inputs.mcloud-timeout }} \
+          --gpu_num ${{ matrix.gpu_num }} \
           --git_ssh_clone ${{ inputs.git-ssh-clone }} \
           ${REF_ARGS}

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -52,15 +52,10 @@ jobs:
     env:
       MOSAICML_API_KEY: ${{ secrets.mcloud-api-key }}
     steps:
-    - name: Print Git Info
-      run: |
-        echo "Branch: 4gpu-testing"
-        echo "SHA: ${{ github.sha }}"
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
         repository: "mosaicml/ci-testing"
-        ref: "4gpu-testing"
     - name: Setup Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This PR allows for 1, 2, or 4 GPU runs for tests:
 - If only 1 GPU is requested, the script runs make test.
 - If more than 1 GPU is requested, the script runs make test-dist with the appropriate WORLD_SIZE parameter.

gpu_configurations input now accepts a comma-separated list of GPU counts (e.g., "1,2,4"), creating corresponding jobs for each count, and will create three jobs:
 - Job with 1 GPU, running make test
 - Job with 2 GPUs, running make test-dist with WORLD_SIZE=2
 - Job with 4 GPUs, running make test-dist with WORLD_SIZE=4
https://github.com/mosaicml/composer/actions/runs/9215566607/job/25354289104?pr=3312