### PR TITLE
Fix versioned gpu test bug

### DIFF
--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -64,6 +64,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: "mosaicml/ci-testing"
+        ref: "v0.0.8"
     - name: Setup Python
       uses: actions/setup-python@v4
       with:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# ci-testing
+This repository contains code for CI/CD and testing of MosaicML repos including [Composer](https://github.com/mosaicml/composer) and [Foundry](https://github.com/mosaicml/llm-foundry).
+
+# Release Instructions
+Update the version in `.github/workflows/pytest-gpu.yaml` when releasing a new version of `mosaicml/ci-testing`.


### PR DESCRIPTION
Adds a version tag when checking out ci-testing. Without this, any repo that attempts to run the gpu test workflow, no matter what workflow version is being used, will use the latest mcli_pytest file.

Tested in https://github.com/mosaicml/llm-foundry/actions/runs/9699947884/job/26770172601?pr=1309