### PR TITLE
[DO NOT MERGE] Revert "update runners"

### DIFF
--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -55,7 +55,7 @@ on:
 jobs:
   pytest-cpu:
     timeout-minutes: 30
-    runs-on: linux-ubuntu-latest
+    runs-on: ubuntu-latest
     container: ${{ inputs.container }}
     steps:
     - name: Checkout Repo

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -56,7 +56,7 @@ on:
 jobs:
   pytest-gpu:
     timeout-minutes: ${{ inputs.gha-timeout }}
-    runs-on: linux-ubuntu-latest
+    runs-on: ubuntu-latest
     env:
       MOSAICML_API_KEY: ${{ secrets.mcloud-api-key }}
     steps:


### PR DESCRIPTION
Reverts mosaicml/ci-testing#15
Larger runners cannot be used cross org, even if they exist in both orgs