### PR TITLE
remove pip pin

### DIFF
--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -17,7 +17,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade 'pip<23' wheel
+      python -m pip install --upgrade pip wheel
       python -m pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -10,7 +10,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade 'pip<23' wheel
+      python -m pip install --upgrade pip wheel
       pip install coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -71,7 +71,7 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      python -m pip install --upgrade 'pip<23' wheel
+      python -m pip install --upgrade pip wheel
       python -m pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -13,7 +13,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade 'pip<23' wheel
+      python -m pip install --upgrade pip wheel
       python -m pip install --upgrade .
       python -m pip install pytest==7.2.1 pytest_codeblocks==0.16.1
   - name: Run checks


### PR DESCRIPTION
It seems that the latest versions of wheel/setuptools don't work with old pip versions. I had some trouble isolating that exact dependency combination that doesn't work, but upgrading pip definitely worked. This issue is reproducible locally. Also confirmed that CI on the repo now works (see slack).

The symptom is that it just doesn't install extra dependency groups for local installs.