### PR TITLE
Deprecate container input in favor of job input

### DIFF
--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -3,9 +3,6 @@ inputs:
   name:
     required: true
     type: string
-  container:
-    required: true
-    type: string
   gpu_num:
     required: true
     type: number


### PR DESCRIPTION
When calling the action in our new workflow, we pass the container directly to the job, not to the called workflow.
https://github.com/mosaicml/composer/pull/3486/files#diff-d2fbd15d78268159289b9e9e6a286bb3b30e4cf4772f6161320992fd461f52c4R14

When this is released, any actions using the release will need to update their jobs:
1. To the new workflow method (if not already)
2. Remove the container input and instead define `container: <container> or ${{ matrix.container }}` in their job. 