### PR TITLE
pip -> uv

### DIFF
--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -23,7 +23,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install --system uv
+      pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -23,9 +23,9 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .${{ inputs.pip_deps }}
+      pip install --system uv
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -16,16 +16,16 @@ runs:
   - name: Activate virtualenv
     shell: bash
     run: |
-      python -m venv .venv
-      . .venv/bin/activate
+      python -m venv ../.venv
+      . ../.venv/bin/activate
       echo PATH=$PATH >> $GITHUB_ENV
   - name: Setup
     shell: bash
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .${{ inputs.pip_deps }}
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -18,8 +18,8 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .${{ inputs.pip_deps }}
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -17,8 +17,9 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade pip wheel
-      python -m pip install --upgrade .${{ inputs.pip_deps }}
+      pip install uv
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -17,10 +17,13 @@ runs:
     shell: bash
     run: |
       set -ex
+      python -m venv ~/.local
+      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |
+      source ~/.local/bin/activate
       pre-commit run --all-files

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -13,17 +13,20 @@ runs:
   - uses: actions/setup-python@v4
     with:
       python-version: ${{ inputs.python_version }}
+  - name: Activate virtualenv
+    shell: bash
+    run: |
+      python -m venv .venv
+      . .venv/bin/activate
+      echo PATH=$PATH >> $GITHUB_ENV
   - name: Setup
     shell: bash
     run: |
       set -ex
-      python -m venv ~/.local
-      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |
-      source ~/.local/bin/activate
       pre-commit run --all-files

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -24,8 +24,8 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .${{ inputs.pip_deps }}
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -24,8 +24,8 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade --system pip wheel
-      uv pip install --upgrade --system .${{ inputs.pip_deps }}
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -16,7 +16,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install --system uv
+      pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --system coverage[toml]==6.5.0
   - name: Download artifacts

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -6,12 +6,16 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Activate virtualenv
+    shell: bash
+    run: |
+      python -m venv .venv
+      . .venv/bin/activate
+      echo PATH=$PATH >> $GITHUB_ENV
   - name: Setup
     shell: bash
     run: |
       set -ex
-      python -m venv ~/.local
-      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --system coverage[toml]==6.5.0
@@ -23,7 +27,6 @@ runs:
     shell: bash
     run: |
       set -ex
-      source ~/.local/bin/activate
       # Flatten the coverage files
       # yamllint disable-line rule:line-length
       ls ${{ inputs.download-path }} | while read x; do mv ${{ inputs.download-path }}/$x/.coverage .coverage.$x; done

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -17,8 +17,8 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade --system pip wheel
-      uv pip install --system coverage[toml]==6.5.0
+      uv pip install --upgrade pip wheel
+      uv pip install coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -11,8 +11,8 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install coverage[toml]==6.5.0
+      uv pip install --upgrade --system pip wheel
+      uv pip install --system coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -10,8 +10,9 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade pip wheel
-      pip install coverage[toml]==6.5.0
+      pip install uv
+      uv pip install --upgrade pip wheel
+      uv pip install coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -10,6 +10,8 @@ runs:
     shell: bash
     run: |
       set -ex
+      python -m venv ~/.local
+      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --system coverage[toml]==6.5.0
@@ -21,7 +23,7 @@ runs:
     shell: bash
     run: |
       set -ex
-
+      source ~/.local/bin/activate
       # Flatten the coverage files
       # yamllint disable-line rule:line-length
       ls ${{ inputs.download-path }} | while read x; do mv ${{ inputs.download-path }}/$x/.coverage .coverage.$x; done

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -16,9 +16,9 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install coverage[toml]==6.5.0
+      pip install --system uv
+      uv pip install --upgrade --system pip wheel
+      uv pip install --system coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -72,8 +72,8 @@ runs:
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
       pip install uv
-      uv pip install --upgrade --system pip wheel
-      uv pip install --upgrade --system .${{ inputs.pip_deps }}
+      uv pip install --upgrade --user pip wheel
+      uv pip install --upgrade --user .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -72,8 +72,8 @@ runs:
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
       pip install uv
-      uv pip install --upgrade --user pip wheel
-      uv pip install --upgrade --user .${{ inputs.pip_deps }}
+      uv pip install --upgrade --target "$(python3 -m site --user-site)" pip wheel
+      uv pip install --upgrade --target "$(python3 -m site --user-site)" .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -74,8 +74,8 @@ runs:
       python -m venv ~/.local
       source ~/.local/bin/activate
       pip install uv
-      uv pip install --upgrade --target "$(python3 -m site --user-site)" pip wheel
-      uv pip install --upgrade --target "$(python3 -m site --user-site)" .${{ inputs.pip_deps }}
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -71,8 +71,9 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      python -m pip install --upgrade pip wheel
-      python -m pip install --upgrade .${{ inputs.pip_deps }}
+      pip install uv
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -65,14 +65,18 @@ runs:
   steps:
   - name: Checkout
     uses: actions/checkout@v3
+  - name: Activate virtualenv
+    shell: bash
+    run: |
+      python -m venv .venv
+      . .venv/bin/activate
+      echo PATH=$PATH >> $GITHUB_ENV
   - name: Setup
     shell: bash
     run: |
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      python -m venv ~/.local
-      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade pip wheel
       uv pip install --upgrade .${{ inputs.pip_deps }}
@@ -81,7 +85,6 @@ runs:
     shell: bash
     run: |
       set -ex
-      source ~/.local/bin/activate
       export PATH=/composer-python:$PATH
       export WANDB_API_KEY='${{ inputs.wandb_api_key }}'
       export WANDB_ENTITY='${{ inputs.pytest_wandb_entity }}'

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -71,6 +71,8 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
+      python -m venv ~/.local
+      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --target "$(python3 -m site --user-site)" pip wheel
       uv pip install --upgrade --target "$(python3 -m site --user-site)" .${{ inputs.pip_deps }}
@@ -79,6 +81,7 @@ runs:
     shell: bash
     run: |
       set -ex
+      source ~/.local/bin/activate
       export PATH=/composer-python:$PATH
       export WANDB_API_KEY='${{ inputs.wandb_api_key }}'
       export WANDB_ENTITY='${{ inputs.pytest_wandb_entity }}'

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -78,8 +78,8 @@ runs:
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
       pip install uv
-      uv pip install --upgrade --system pip wheel
-      uv pip install --upgrade --system .${{ inputs.pip_deps }}
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -77,7 +77,7 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      pip install --system uv
+      pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run Tests

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -77,9 +77,9 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .${{ inputs.pip_deps }}
+      pip install --system uv
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -72,8 +72,8 @@ runs:
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .${{ inputs.pip_deps }}
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -77,16 +77,6 @@ runs:
         python -m venv .venv
         . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
-    # - name: Cache pip
-    #   uses: actions/cache@v3
-    #   with:
-    #     # This path is specific to Ubuntu
-    #     path: ~/.cache/pip
-    #     # Look to see if there is a cache hit for the corresponding requirements file
-    #     key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-pip-
-    #       ${{ runner.os }}-
     - name: Setup MCLI
       shell: bash
       run: |
@@ -103,6 +93,7 @@ runs:
         CODE_EVAL_DEVICE: ${{ inputs.code_eval_device }}
         CODE_EVAL_URL: ${{ inputs.code_eval_url }}
         CODE_EVAL_APIKEY: ${{ inputs.code_eval_apikey }}
+        VIRTUAL_ENV: ${{ runner.workspace }}/.venv
       run: |
         set -ex
         PR_NUMBER="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -82,7 +82,7 @@ runs:
       run: |
         set -ex
         pip install uv
-        uv pip install --system mosaicml-cli
+        uv pip install mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests
@@ -93,7 +93,6 @@ runs:
         CODE_EVAL_DEVICE: ${{ inputs.code_eval_device }}
         CODE_EVAL_URL: ${{ inputs.code_eval_url }}
         CODE_EVAL_APIKEY: ${{ inputs.code_eval_apikey }}
-        VIRTUAL_ENV: ${{ runner.workspace }}/.venv
       run: |
         set -ex
         PR_NUMBER="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -71,6 +71,12 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
+    - name: Activate virtualenv
+      shell: bash
+      run: |
+        python -m venv .venv
+        . .venv/bin/activate
+        echo PATH=$PATH >> $GITHUB_ENV
     - name: Cache pip
       uses: actions/cache@v3
       with:
@@ -85,8 +91,6 @@ runs:
       shell: bash
       run: |
         set -ex
-        python -m venv ~/.local
-        source ~/.local/bin/activate
         pip install uv
         uv pip install --system mosaicml-cli
         mcli version
@@ -116,7 +120,7 @@ runs:
           REF_ARGS="--pr_number $PR_NUMBER"
         fi
 
-        ~/.local/bin/python .github/mcli/mcli_pytest.py \
+        python .github/mcli/mcli_pytest.py \
           --image '${{ inputs.container }}' \
           --git_repo '${{ inputs.git_repo }}' \
           --pip_deps '${{ inputs.pip_deps }}' \
@@ -133,7 +137,7 @@ runs:
         MOSAICML_API_KEY: ${{ inputs.mcloud_api_key }}
       run: |
         set -ex
-        ~/.local/bin/python .github/mcli/follow_mcli_logs.py \
+        python .github/mcli/follow_mcli_logs.py \
           --name '${{ steps.tests.outputs.RUN_NAME }}'
     - name: Stop Run if Cancelled
       if: ${{ cancelled() }}
@@ -142,5 +146,5 @@ runs:
         MOSAICML_API_KEY: ${{ inputs.mcloud_api_key }}
       run: |
         set -ex
-        ~/.local/bin/python .github/mcli/cancel_mcli_run.py \
+        python .github/mcli/cancel_mcli_run.py \
           --name '${{ steps.tests.outputs.RUN_NAME }}'

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -85,6 +85,8 @@ runs:
       shell: bash
       run: |
         set -ex
+        python -m venv ~/.local
+        source ~/.local/bin/activate
         pip install uv
         uv pip install --system mosaicml-cli
         mcli version
@@ -99,7 +101,7 @@ runs:
         CODE_EVAL_APIKEY: ${{ inputs.code_eval_apikey }}
       run: |
         set -ex
-
+        source ~/.local/bin/activate
         PR_NUMBER="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
         REF_ARGS=""
 
@@ -132,7 +134,7 @@ runs:
         MOSAICML_API_KEY: ${{ inputs.mcloud_api_key }}
       run: |
         set -ex
-
+        source ~/.local/bin/activate
         python .github/mcli/follow_mcli_logs.py \
           --name '${{ steps.tests.outputs.RUN_NAME }}'
     - name: Stop Run if Cancelled
@@ -142,6 +144,6 @@ runs:
         MOSAICML_API_KEY: ${{ inputs.mcloud_api_key }}
       run: |
         set -ex
-
+        source ~/.local/bin/activate
         python .github/mcli/cancel_mcli_run.py \
           --name '${{ steps.tests.outputs.RUN_NAME }}'

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -91,7 +91,7 @@ runs:
       shell: bash
       run: |
         set -ex
-        pip install --system uv
+        pip install uv
         uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -101,7 +101,6 @@ runs:
         CODE_EVAL_APIKEY: ${{ inputs.code_eval_apikey }}
       run: |
         set -ex
-        source ~/.local/bin/activate
         PR_NUMBER="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
         REF_ARGS=""
 
@@ -117,7 +116,7 @@ runs:
           REF_ARGS="--pr_number $PR_NUMBER"
         fi
 
-        python .github/mcli/mcli_pytest.py \
+        ~/.local/bin/python .github/mcli/mcli_pytest.py \
           --image '${{ inputs.container }}' \
           --git_repo '${{ inputs.git_repo }}' \
           --pip_deps '${{ inputs.pip_deps }}' \
@@ -134,8 +133,7 @@ runs:
         MOSAICML_API_KEY: ${{ inputs.mcloud_api_key }}
       run: |
         set -ex
-        source ~/.local/bin/activate
-        python .github/mcli/follow_mcli_logs.py \
+        ~/.local/bin/python .github/mcli/follow_mcli_logs.py \
           --name '${{ steps.tests.outputs.RUN_NAME }}'
     - name: Stop Run if Cancelled
       if: ${{ cancelled() }}
@@ -144,6 +142,5 @@ runs:
         MOSAICML_API_KEY: ${{ inputs.mcloud_api_key }}
       run: |
         set -ex
-        source ~/.local/bin/activate
-        python .github/mcli/cancel_mcli_run.py \
+        ~/.local/bin/python .github/mcli/cancel_mcli_run.py \
           --name '${{ steps.tests.outputs.RUN_NAME }}'

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -85,7 +85,8 @@ runs:
       shell: bash
       run: |
         set -ex
-        python -m pip install mosaicml-cli
+        pip install uv
+        uv pip install mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -86,7 +86,7 @@ runs:
       run: |
         set -ex
         pip install uv
-        uv pip install mosaicml-cli
+        uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -91,8 +91,8 @@ runs:
       shell: bash
       run: |
         set -ex
-        pip install uv
-        uv pip install mosaicml-cli
+        pip install --system uv
+        uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -82,7 +82,7 @@ runs:
       run: |
         set -ex
         pip install uv
-        uv pip install mosaicml-cli
+        uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -92,7 +92,7 @@ runs:
       run: |
         set -ex
         pip install uv
-        uv pip install mosaicml-cli
+        uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -92,7 +92,7 @@ runs:
       run: |
         set -ex
         pip install uv
-        uv pip install --system mosaicml-cli
+        uv pip install mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -77,16 +77,16 @@ runs:
         python -m venv .venv
         . .venv/bin/activate
         echo PATH=$PATH >> $GITHUB_ENV
-    - name: Cache pip
-      uses: actions/cache@v3
-      with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+    # - name: Cache pip
+    #   uses: actions/cache@v3
+    #   with:
+    #     # This path is specific to Ubuntu
+    #     path: ~/.cache/pip
+    #     # Look to see if there is a cache hit for the corresponding requirements file
+    #     key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-pip-
+    #       ${{ runner.os }}-
     - name: Setup MCLI
       shell: bash
       run: |

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -9,12 +9,16 @@ runs:
   - uses: actions/setup-python@v4
     with:
       python-version: ${{ inputs.python_version }}
+  - name: Activate virtualenv
+    shell: bash
+    run: |
+      python -m venv .venv
+      . .venv/bin/activate
+      echo PATH=$PATH >> $GITHUB_ENV
   - name: Setup
     shell: bash
     run: |
       set -ex
-      python -m venv ~/.local
-      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --upgrade --system .
@@ -22,5 +26,4 @@ runs:
   - name: Run checks
     shell: bash
     run: |
-      source ~/.local/bin/activate
       pytest tests/test_smoketest.py

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -13,6 +13,8 @@ runs:
     shell: bash
     run: |
       set -ex
+      python -m venv ~/.local
+      source ~/.local/bin/activate
       pip install uv
       uv pip install --upgrade --system pip wheel
       uv pip install --upgrade --system .
@@ -20,4 +22,5 @@ runs:
   - name: Run checks
     shell: bash
     run: |
+      source ~/.local/bin/activate
       pytest tests/test_smoketest.py

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -20,9 +20,9 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade --system pip wheel
-      uv pip install --upgrade --system .
-      uv pip install --system pytest==7.2.1 pytest_codeblocks==0.16.1
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .
+      uv pip install pytest==7.2.1 pytest_codeblocks==0.16.1
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -13,9 +13,10 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade pip wheel
-      python -m pip install --upgrade .
-      python -m pip install pytest==7.2.1 pytest_codeblocks==0.16.1
+      pip install uv
+      uv pip install --upgrade pip wheel
+      uv pip install --upgrade .
+      uv pip install pytest==7.2.1 pytest_codeblocks==0.16.1
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -14,9 +14,9 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .
-      uv pip install pytest==7.2.1 pytest_codeblocks==0.16.1
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .
+      uv pip install --system pytest==7.2.1 pytest_codeblocks==0.16.1
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -20,9 +20,9 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install --upgrade .
-      uv pip install pytest==7.2.1 pytest_codeblocks==0.16.1
+      uv pip install --upgrade --system pip wheel
+      uv pip install --upgrade --system .
+      uv pip install --system pytest==7.2.1 pytest_codeblocks==0.16.1
   - name: Run checks
     shell: bash
     run: |

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -67,6 +67,12 @@ if __name__ == '__main__':
     which python
     which pip
 
+    python -m venv --system-site-packages .venv
+    . .venv/bin/activate
+
+    which python
+    which pip
+
     pip install uv
     uv pip install --upgrade --system --no-build-isolation .{args.pip_deps}
 

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,17 +64,11 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
-    which python
-    which pip
-
     python -m venv --system-site-packages .venv
     . .venv/bin/activate
 
-    which python
-    which pip
-
     pip install uv
-    uv pip install --upgrade --system --no-build-isolation .{args.pip_deps}
+    uv pip install --upgrade --no-build-isolation .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
     which python
     which pip
 
-    pip install --system uv
+    pip install uv
     uv pip install --upgrade --system --no-build-isolation .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
     pip install uv
-    uv pip install --upgrade --system .{args.pip_deps}
+    uv pip install --upgrade --system --no-build-isolation .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,8 +64,11 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
+    python -m venv --system-site-packages .venv
+    . .venv/bin/activate
+
     pip install uv
-    uv pip install --upgrade --system --no-build-isolation .{args.pip_deps}
+    uv pip install --upgrade --no-build-isolation .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,8 +64,8 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
-    python -m venv --system-site-packages .venv
-    . .venv/bin/activate
+    which python
+    which pip
 
     pip install uv
     uv pip install --upgrade --no-build-isolation .{args.pip_deps}

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -67,8 +67,8 @@ if __name__ == '__main__':
     which python
     which pip
 
-    pip install uv
-    uv pip install --upgrade --no-build-isolation .{args.pip_deps}
+    pip install --system uv
+    uv pip install --upgrade --system --no-build-isolation .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,7 +64,8 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
-    pip install --upgrade --user .{args.pip_deps}
+    pip install uv
+    uv pip install --upgrade --user .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,11 +64,8 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
-    python -m venv .venv
-    . .venv/bin/activate
-
     pip install uv
-    uv pip install --upgrade .{args.pip_deps}
+    uv pip install --upgrade --system .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
     pip install uv
-    uv pip install --upgrade --user .{args.pip_deps}
+    uv pip install --upgrade --system .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,8 +64,11 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
+    python -m venv .venv
+    . .venv/bin/activate
+
     pip install uv
-    uv pip install --upgrade --system .{args.pip_deps}
+    uv pip install --upgrade .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''


### PR DESCRIPTION
Replace pip with uv. This reduces the time every action takes by 3-4 minutes because uv is just that much faster at installing things. Tested this PR against LLM Foundry (last commit [here](https://github.com/mosaicml/llm-foundry/pull/1500)) and an internal repo to ensure it works. I do not fully understand the specific incantations that were needed to get everything to install correctly...but it does seem to work. 