### PR TITLE
Reapply the pip -> uv replacement

### DIFF
--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -17,9 +17,9 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install uve
-      python -m pip install --upgrade pip wheel
-      python -m pip install --system .${{ inputs.pip_deps }}
+      pip install uv
+      uv pip install --upgrade pip wheel
+      uv pip install --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -17,8 +17,9 @@ runs:
     shell: bash
     run: |
       set -ex
+      pip install uve
       python -m pip install --upgrade pip wheel
-      python -m pip install --upgrade .${{ inputs.pip_deps }}
+      python -m pip install --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash
     run: |

--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -18,7 +18,7 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
+      uv pip install --upgrade --system pip wheel
       uv pip install --system .${{ inputs.pip_deps }}
   - name: Run checks
     shell: bash

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -10,8 +10,9 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade pip wheel
-      pip install coverage[toml]==6.5.0
+      pip install uv
+      uv pip install --upgrade --system pip wheel
+      uv pip install --system coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -6,13 +6,16 @@ inputs:
 runs:
   using: composite
   steps:
+  - uses: actions/setup-python@v4
+    with:
+      python-version: "3.11"
   - name: Setup
     shell: bash
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade pip wheel
-      uv pip install coverage[toml]==6.5.0
+      uv pip install --upgrade --system pip wheel
+      uv pip install --system coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -11,8 +11,8 @@ runs:
     run: |
       set -ex
       pip install uv
-      uv pip install --upgrade --system pip wheel
-      uv pip install --system coverage[toml]==6.5.0
+      uv pip install --upgrade pip wheel
+      uv pip install coverage[toml]==6.5.0
   - name: Download artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -102,6 +102,7 @@ runs:
       which pip
       which pytest
       which composer
+      python -c "import transformers; print(transformers.__file__)"
 
       python -m coverage combine
   - uses: actions/upload-artifact@v3

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -100,6 +100,7 @@ runs:
       # make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
       python -m coverage combine
+      ls -al
   - uses: actions/upload-artifact@v3
     with:
       name: coverage-${{ github.sha }}-${{ inputs.name }}

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -105,4 +105,4 @@ runs:
   - uses: actions/upload-artifact@v3
     with:
       name: coverage-${{ github.sha }}-${{ inputs.name }}
-      path: .coverage
+      path: **/.coverage

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -96,8 +96,8 @@ runs:
 
       # Necessary to run git diff for doctests
       git config --global --add safe.directory /__w/${{ inputs.safe_directory }}/${{ inputs.safe_directory }}
-      make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks tests/optim/test_scheduler.py"
-      # make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
+      make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
+      make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
       python -m coverage combine
   - uses: actions/upload-artifact@v3

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -94,12 +94,6 @@ runs:
       export AZURE_ACCOUNT_ACCESS_KEY='${{ inputs.azure_account_access_key }}'
       export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest_markers }}' -o tmp_path_retention_policy=failed"
 
-      which python
-      which pip
-      which pytest
-      which composer
-      python -c "import transformers; print(transformers.__file__)"
-
       # Necessary to run git diff for doctests
       git config --global --add safe.directory /__w/${{ inputs.safe_directory }}/${{ inputs.safe_directory }}
       make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -105,4 +105,4 @@ runs:
   - uses: actions/upload-artifact@v3
     with:
       name: coverage-${{ github.sha }}-${{ inputs.name }}
-      path: **/.coverage
+      path: /__w/**/.coverage

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -93,16 +93,16 @@ runs:
       export AZURE_ACCOUNT_ACCESS_KEY='${{ inputs.azure_account_access_key }}'
       export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest_markers }}' -o tmp_path_retention_policy=failed"
 
-      # Necessary to run git diff for doctests
-      git config --global --add safe.directory /__w/${{ inputs.safe_directory }}/${{ inputs.safe_directory }}
-      make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
-      make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
-
       which python
       which pip
       which pytest
       which composer
       python -c "import transformers; print(transformers.__file__)"
+
+      # Necessary to run git diff for doctests
+      git config --global --add safe.directory /__w/${{ inputs.safe_directory }}/${{ inputs.safe_directory }}
+      make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
+      make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
       python -m coverage combine
   - uses: actions/upload-artifact@v3

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -100,9 +100,8 @@ runs:
       # make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
       python -m coverage combine
-      ls -al
-      pwd
   - uses: actions/upload-artifact@v3
     with:
       name: coverage-${{ github.sha }}-${{ inputs.name }}
-      path: llm-foundry/llm-foundry/.coverage
+      include-hidden-files: true
+      path: .coverage

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -105,4 +105,4 @@ runs:
   - uses: actions/upload-artifact@v3
     with:
       name: coverage-${{ github.sha }}-${{ inputs.name }}
-      path: /__w/**/.coverage
+      path: llm-foundry/llm-foundry/.coverage

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -72,8 +72,8 @@ runs:
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
       pip install uv
-      python -m pip install --system --upgrade pip wheel
-      python -m pip install --system .${{ inputs.pip_deps }}
+      uv pip install --system --upgrade pip wheel
+      uv pip install --system .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -71,8 +71,9 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      python -m pip install --upgrade pip wheel
-      python -m pip install --upgrade .${{ inputs.pip_deps }}
+      pip install uv
+      python -m pip install --system --upgrade pip wheel
+      python -m pip install --system .${{ inputs.pip_deps }}
   - name: Run Tests
     id: tests
     shell: bash

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -98,6 +98,11 @@ runs:
       make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
       make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
+      which python
+      which pip
+      which pytest
+      which composer
+
       python -m coverage combine
   - uses: actions/upload-artifact@v3
     with:

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -101,6 +101,7 @@ runs:
 
       python -m coverage combine
       ls -al
+      pwd
   - uses: actions/upload-artifact@v3
     with:
       name: coverage-${{ github.sha }}-${{ inputs.name }}

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -96,8 +96,8 @@ runs:
 
       # Necessary to run git diff for doctests
       git config --global --add safe.directory /__w/${{ inputs.safe_directory }}/${{ inputs.safe_directory }}
-      make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
-      make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
+      make test PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks tests/optim/test_scheduler.py"
+      # make test-dist PYTEST='${{ inputs.pytest_command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
 
       python -m coverage combine
   - uses: actions/upload-artifact@v3

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -85,7 +85,8 @@ runs:
       shell: bash
       run: |
         set -ex
-        python -m pip install mosaicml-cli
+        pip install uv
+        uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run
       id: tests

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -13,9 +13,10 @@ runs:
     shell: bash
     run: |
       set -ex
-      python -m pip install --upgrade pip wheel
-      python -m pip install --upgrade .
-      python -m pip install pytest==7.2.1 pytest_codeblocks==0.16.1
+      pip install uv
+      uv pip install --upgrade --system pip wheel
+      uv pip install --system .
+      uv pip install --system pytest==7.2.1 pytest_codeblocks==0.16.1
   - name: Run checks
     shell: bash
     run: |

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,7 +64,9 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
-    pip install --upgrade --user .{args.pip_deps}
+    pip install uv
+
+    uv pip install --system .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
 
     pip install uv
 
-    uv pip install --system .{args.pip_deps}
+    uv pip install --system --no-build-isolation .{args.pip_deps}
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {clear_tmp_path_flag}"
     '''


### PR DESCRIPTION
Reapplies pip -> uv. Fixes downstream workflows to use the expected container, or adds a setup python step, so that `--system` works everywhere without need for virtualenvs. Additionally, unrelated to this change, github actions pushed a breaking change that broke our coverage workflow, so this also resolves that (https://github.com/actions/upload-artifact/issues/602).