### PR TITLE
Add safe dir for lint

### DIFF
--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -7,6 +7,9 @@ inputs:
   pip_deps:
     required: true
     type: string
+  safe_directory:
+    required: true
+    type: string
 runs:
   using: composite
   steps:
@@ -23,4 +26,5 @@ runs:
   - name: Run checks
     shell: bash
     run: |
+      git config --global --add safe.directory /__w/${{ inputs.safe_directory }}/${{ inputs.safe_directory }}
       pre-commit run --all-files


### PR DESCRIPTION
Add safe dir for lint. Copies changes in CPU workflow.

Note this is a new flag so I will bump minor version.