### PR TITLE
Add retry logic to create_run

### DIFF
--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -9,20 +9,6 @@ import time
 
 from mcli import RunConfig, create_run
 
-def retry_create_run(config):
-    sleep_time = 1
-    retries = 3
-    timeout = 30
-    while retries > 0:
-        try:
-            create_run(config, timeout=timeout)
-        except Exception as e:
-            print(f"Create run failed, retrying {sleep_time} more time(s).")
-            time.sleep(sleep_time)
-            sleep_time *= 2
-            retries -= 1
-            
-    
 
 if __name__ == '__main__':
 
@@ -126,7 +112,7 @@ if __name__ == '__main__':
     )
 
     # Create run
-    retry_create_run(config)
+    create_run(config, timeout=30)
 
     print(f'[GHA] Run created: {run.name}')
 

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -5,10 +5,8 @@
 
 import argparse
 import os
-import time 
 
 from mcli import RunConfig, create_run
-
 
 if __name__ == '__main__':
 
@@ -113,7 +111,6 @@ if __name__ == '__main__':
 
     # Create run
     create_run(config, timeout=30)
-
     print(f'[GHA] Run created: {run.name}')
 
     with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -12,7 +12,7 @@ from mcli import RunConfig, create_run
 def retry_create_run(config):
     sleep_time = 1
     retries = 3
-    timeout = 10
+    timeout = 30
     while retries > 0:
         try:
             create_run(config, timeout=timeout)

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -12,9 +12,10 @@ from mcli import RunConfig, create_run
 def retry_create_run(config):
     sleep_time = 1
     retries = 3
+    timeout = 10
     while retries > 0:
         try:
-            create_run(config)
+            create_run(config, timeout=timeout)
         except Exception as e:
             print(f"Create run failed, retrying {sleep_time} more time(s).")
             time.sleep(sleep_time)

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -16,6 +16,7 @@ def retry_create_run(config):
         try:
             create_run(config)
         except Exception as e:
+            print(f"Create run failed, retrying {sleep_time} more time(s).")
             time.sleep(sleep_time)
             sleep_time *= 2
             retries -= 1

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
     )
 
     # Create run
-    create_run(config, timeout=30)
+    run = create_run(config, timeout=30)
     print(f'[GHA] Run created: {run.name}')
 
     with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -5,8 +5,22 @@
 
 import argparse
 import os
+import time 
 
 from mcli import RunConfig, create_run
+
+def retry_create_run(config):
+    sleep_time = 1
+    retries = 3
+    while retries > 0:
+        try:
+            create_run(config)
+        except Exception as e:
+            time.sleep(sleep_time)
+            sleep_time *= 2
+            retries -= 1
+            
+    
 
 if __name__ == '__main__':
 
@@ -110,7 +124,8 @@ if __name__ == '__main__':
     )
 
     # Create run
-    run = create_run(config)
+    retry_create_run(config)
+
     print(f'[GHA] Run created: {run.name}')
 
     with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:


### PR DESCRIPTION
# Description
Add retry logic to create_run

# Issues Fixed
Tests failed here because create_run timed out 
https://github.com/mosaicml/composer/actions/runs/11452297889/job/31901019192#step:3:348

Adding a retry here should help