### PR TITLE
Downgrade `uv` to 0.6.5

### DIFF
--- a/.github/actions/code-quality/action.yaml
+++ b/.github/actions/code-quality/action.yaml
@@ -17,7 +17,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install uv
+      pip install uv==0.6.5
       uv pip install --upgrade --system pip wheel
       uv pip install --system .${{ inputs.pip_deps }}
   - name: Run checks

--- a/.github/actions/coverage/action.yaml
+++ b/.github/actions/coverage/action.yaml
@@ -13,7 +13,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install uv
+      pip install uv==0.6.5
       uv pip install --upgrade --system pip wheel
       uv pip install --system coverage[toml]==6.5.0
   - name: Download artifacts

--- a/.github/actions/pytest-cpu/action.yaml
+++ b/.github/actions/pytest-cpu/action.yaml
@@ -68,7 +68,7 @@ runs:
       set -ex
       export PATH=/composer-python:$PATH
       export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
-      pip install uv
+      pip install uv==0.6.5
       uv pip install --system --upgrade pip wheel
       uv pip install --system .${{ inputs.pip_deps }}
   - name: Run Tests

--- a/.github/actions/pytest-gpu/action.yaml
+++ b/.github/actions/pytest-gpu/action.yaml
@@ -93,7 +93,7 @@ runs:
       shell: bash
       run: |
         set -ex
-        pip install uv
+        pip install uv==0.6.5
         uv pip install --system mosaicml-cli
         mcli version
     - name: Submit Run

--- a/.github/actions/smoketest/action.yaml
+++ b/.github/actions/smoketest/action.yaml
@@ -13,7 +13,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      pip install uv
+      pip install uv==0.6.5
       uv pip install --upgrade --system pip wheel
       uv pip install --system .
       uv pip install --system pytest==7.2.1 pytest_codeblocks==0.16.1

--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
 
     export COMPOSER_PACKAGE_NAME='{args.pip_package_name}'
 
-    pip install uv
+    pip install uv==0.6.5
 
     uv pip install --system --no-build-isolation .{args.pip_deps}
 


### PR DESCRIPTION
`uv` had a recent release to `0.6.6` which breaks our CI for other repositories (specifically, build failures for flash attention and turbo in our GPU tests), so we are attempting to downgrade it to the latest release before the failures occurred `0.6.5`. Although it's not needed in most other locations, uniformity of uv versions is probably for the best.