### PR TITLE
Fix deprecation warning in mcli_pytest.py

### DIFF
--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -97,16 +97,10 @@ if __name__ == '__main__':
         integrations=[git_integration],
         command=command,
         scheduling={'max_duration': args.timeout / 60 / 60},
-        env_variables=[
-            {
-                'key': 'MOSAICML_PLATFORM',
-                'value': 'False',
-            },
-            {
-                'key': 'PYTHONUNBUFFERED',
-                'value': '1',
-            },
-        ],
+        env_variables={
+            'MOSAICML_PLATFORM': 'False',
+            'PYTHONUNBUFFERED': '1',
+        },
     )
 
     # Create run


### PR DESCRIPTION
## Summary
- Fixed deprecation warning about env_variables parameter format in mcli_pytest.py
- Changed env_variables from list of key-value dictionaries to simple dict mapping

## Changes
- Updated env_variables parameter in RunConfig from:
  ```python
  env_variables=[
      {'key': 'MOSAICML_PLATFORM', 'value': 'False'},
      {'key': 'PYTHONUNBUFFERED', 'value': '1'},
  ]
  ```
  to:
  ```python
  env_variables={
      'MOSAICML_PLATFORM': 'False',
      'PYTHONUNBUFFERED': '1',
  }
  ```

This change addresses the UserWarning: `Support for passing env_variables as a list will soon be deprecated. Please use a dict instead.`